### PR TITLE
fix: prune returned bundles

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -521,6 +521,8 @@ func (pool *TxPool) MevBundles(blockNumber *big.Int, blockTimestamp uint64) ([]t
 
 		// return the ones which are in time
 		txBundles = append(txBundles, bundle.txs)
+		// keep the bundles around internally until they need to be pruned
+		bundles = append(bundles, bundle)
 	}
 
 	pool.mevBundles = bundles

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -508,12 +508,6 @@ func (pool *TxPool) MevBundles(blockNumber *big.Int, blockTimestamp uint64) ([]t
 	var bundles []mevBundle
 
 	for _, bundle := range pool.mevBundles {
-		// Bundles with `0` as the target block should be queued immediately
-		if bundle.blockNumber.Cmp(big.NewInt(0)) == 0 {
-			txBundles = append(txBundles, bundle.txs)
-			continue
-		}
-
 		// Prune outdated bundles
 		if (bundle.maxTimestamp != 0 && blockTimestamp > bundle.maxTimestamp) || blockNumber.Cmp(bundle.blockNumber) > 0 {
 			continue

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -491,6 +491,11 @@ func (pool *TxPool) Pending() (map[common.Address]types.Transactions, error) {
 	return pending, nil
 }
 
+/// AllMevBundles returns all the MEV Bundles currently in the pool
+func (pool *TxPool) AllMevBundles() []mevBundle {
+	return pool.mevBundles
+}
+
 // MevBundles returns a list of bundles valid for the given blockNumber/blockTimestamp
 // also prunes bundles that are outdated
 func (pool *TxPool) MevBundles(blockNumber *big.Int, blockTimestamp uint64) ([]types.Transactions, error) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -786,7 +786,7 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 
 	if trackProfit {
 		finalBalance := w.current.state.GetBalance(w.coinbase)
-		w.current.profit.Add(w.current.profit, finalBalance.Sub(finalBalance, initialBalance))
+		w.current.profit.Add(w.current.profit, big.NewInt(0).Sub(finalBalance, initialBalance))
 	}
 	gasUsed := new(big.Int).SetUint64(receipt.GasUsed)
 	w.current.profit.Add(w.current.profit, gasUsed.Mul(gasUsed, tx.GasPrice()))


### PR DESCRIPTION
* Previously, bundles that get returned would still remain in the pool which is not something we want
* Users can specify targetBlock = 0, that means "queue up my bundle in the next block"
* Also adds some unit tests for the MevBundles method
* does not short circuit the worker loop if there are no pending txs while there are pending bundles
* does not overwrite the miner's balance (big.Int APIs are gigantic footguns)