### PR TITLE
Fix negative coinbaseDiff inside computeBundleGas

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1253,7 +1253,7 @@ func (w *worker) computeBundleGas(bundle types.Transactions, parent *types.Block
 		}
 
 		totalGasUsed += receipt.GasUsed
-		gasFees.Add(gasFees, new(big.Int).Mul(big.NewInt(int64(totalGasUsed)), tx.GasPrice()))
+		gasFees.Add(gasFees, new(big.Int).Mul(big.NewInt(0).SetUint64(receipt.GasUsed), tx.GasPrice()))
 	}
 	coinbaseBalanceAfter := env.state.GetBalance(w.coinbase)
 	coinbaseDiff := new(big.Int).Sub(new(big.Int).Sub(coinbaseBalanceAfter, gasFees), coinbaseBalanceBefore)


### PR DESCRIPTION
This PR fixes the possible negative bundle gas price, which may lead to the bundle not getting included in the block even though it is profitable.