### PR TITLE
Added websocket support and relevant flags

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: flashbots/mev-geth-demo
-        ref: jason/v0.2
+        ref: v0.2-with-ws
         path: e2e
 
     - run: cd e2e && yarn install
@@ -61,5 +61,5 @@ jobs:
         cd e2e
         GETH=`pwd`/../build/bin/geth ./run.sh &
         sleep 15
-        yarn run demo-simple
-        yarn run demo-contract
+        yarn run demo-ws-simple
+        yarn run demo-ws-contract

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -152,6 +152,8 @@ var (
 		utils.EWASMInterpreterFlag,
 		utils.EVMInterpreterFlag,
 		utils.MinerNotifyFullFlag,
+		utils.RelayWSURL,
+		utils.RelayWSAccessKey,
 		configFileFlag,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -500,6 +500,15 @@ var (
 		Name:  "allow-insecure-unlock",
 		Usage: "Allow insecure account unlocking when account-related RPCs are exposed by http",
 	}
+	// Related to the relay websocket options
+	RelayWSURL = cli.StringFlag{
+		Name:  "relayWSURL",
+		Usage: "URL of the websocket relay sending bundles",
+	}
+	RelayWSAccessKey = cli.StringFlag{
+		Name:  "relayWSKey",
+		Usage: "Access key to authenticate with the relay websocket",
+	}
 	RPCGlobalGasCapFlag = cli.Uint64Flag{
 		Name:  "rpc.gascap",
 		Usage: "Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite)",
@@ -1341,6 +1350,18 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 	}
 	if ctx.GlobalIsSet(TxPoolLifetimeFlag.Name) {
 		cfg.Lifetime = ctx.GlobalDuration(TxPoolLifetimeFlag.Name)
+	}
+	WSURL := ctx.GlobalString(RelayWSURL.Name)
+	if WSURL == "" {
+		log.Warn("Relay websocket URL has not been provided, cannot receive bundles")
+	} else {
+		cfg.RelayWSURL = WSURL
+	}
+	WSKey := ctx.GlobalString(RelayWSAccessKey.Name)
+	if WSKey == "" {
+		log.Warn("Relay websocket access key has not been provided, cannot receive bundles")
+	} else {
+		cfg.RelayWSAccessKey = WSKey
 	}
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -231,6 +231,10 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 }
 
 func (b *EthAPIBackend) SendBundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
+	// If the client is already connected to the relay websocket, ignore bundles from the proxy
+	if b.eth.txPool.WebsocketStatus() {
+		return nil
+	}
 	return b.eth.txPool.AddMevBundle(txs, big.NewInt(blockNumber.Int64()), minTimestamp, maxTimestamp, revertingTxHashes)
 }
 

--- a/node/config.go
+++ b/node/config.go
@@ -164,6 +164,11 @@ type Config struct {
 	// exposed.
 	WSModules []string
 
+	// RelayWSURL is the url of the relay websocket which sends bundles
+	RelayWSURL string
+	// RelayAccessKey is the access key required to authenticate with the relay ws server
+	RelayWSAccessKey string
+
 	// WSExposeAll exposes all API modules via the WebSocket RPC interface rather
 	// than just the public ones.
 	//


### PR DESCRIPTION
[Demo](https://github.com/taarushv/mev-geth-ws-demo)

- Added two command line flags `relayWSURL` and `relayWSKey` for authentication with relay ws
  - Ex: `./build/bin/geth --datadir datadir --rpc --rpcapi debug,personal,eth,net,web3,txpool,admin,miner --miner.etherbase=0xd912aecb07e9f4e1ea8e6b4779e7fb6aa1c3e4d8 --miner.gasprice 0 --mine --miner.threads=8 --relayWSURL="localhost:8080" --relayWSKey="secretABC"`
- Pings the server every 10 seconds, to either reconnect (if the relay ws disconnects) or to check the server heartbeat (if the ws connection has been established)
  - Similar to connection health check on the relay [side](https://github.com/taarushv/mev-geth-ws-demo/blob/6b1eda8ce6db7154078fa657a9c8579c0f5fefec/index.js#L127)
 - Only accepts bundles from the proxy if the websocket connection is down


Relay side ws custom message types (aside from the standard ws messages): 

1. 

```
{
    data: "Successfully connected to relay WS",
    type: "success"
}
```
2.
```
{
    data: {
      encodedTxs: [],
      blockNumber: "",
      minTimestamp: "",
      maxTimestamp: "",
      revertingTxHashes: []
    },
    type: "bundle"
}
```