### PR TITLE
Replaced access key authenitcation for eth signatures

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: flashbots/mev-geth-demo
-        ref: v0.2-with-ws
+        ref: v0.2-ws-eth-keys
         path: e2e
 
     - run: cd e2e && yarn install

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -154,7 +154,7 @@ var (
 		utils.EVMInterpreterFlag,
 		utils.MinerNotifyFullFlag,
 		utils.RelayWSURL,
-		utils.RelayWSAccessKey,
+		utils.RelayWSSigningKey,
 		configFileFlag,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -510,8 +510,8 @@ var (
 		Name:  "relayWSURL",
 		Usage: "URL of the websocket relay sending bundles",
 	}
-	RelayWSAccessKey = cli.StringFlag{
-		Name:  "relayWSKey",
+	RelayWSSigningKey = cli.StringFlag{
+		Name:  "relayWSSigningKey",
 		Usage: "Access key to authenticate with the relay websocket",
 	}
 	RPCGlobalGasCapFlag = cli.Uint64Flag{
@@ -1362,12 +1362,13 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 	} else {
 		cfg.RelayWSURL = WSURL
 	}
-	WSKey := ctx.GlobalString(RelayWSAccessKey.Name)
+	WSKey := ctx.GlobalString(RelayWSSigningKey.Name)
 	if WSKey == "" {
-		log.Warn("Relay websocket access key has not been provided, cannot receive bundles")
+		log.Warn("Relay websocket signing key has not been provided, cannot receive bundles")
 	} else {
-		cfg.RelayWSAccessKey = WSKey
+		cfg.RelayWSSigningKey = WSKey
 	}
+	cfg.Etherbase = ctx.GlobalString(MinerEtherbaseFlag.Name)
 }
 
 func setEthash(ctx *cli.Context, cfg *ethconfig.Config) {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -370,7 +370,6 @@ func (pool *TxPool) getWSAuthSignature() string {
 		log.Warn(err.Error())
 	}
 	message := pool.getUTCTimestamp()
-	log.Info(message)
 	hash := crypto.Keccak256Hash([]byte(message))
 	signature, err := crypto.Sign(hash.Bytes(), privateKey)
 	if err != nil {

--- a/node/config.go
+++ b/node/config.go
@@ -166,8 +166,8 @@ type Config struct {
 
 	// RelayWSURL is the url of the relay websocket which sends bundles
 	RelayWSURL string
-	// RelayAccessKey is the access key required to authenticate with the relay ws server
-	RelayWSAccessKey string
+	// RelayWSSigningKey is the ethereum private key of a whitelisted eoa, required to authenticate with the relay ws server
+	RelayWSSigningKey string
 
 	// WSExposeAll exposes all API modules via the WebSocket RPC interface rather
 	// than just the public ones.


### PR DESCRIPTION
Flag `RelayWSAccessKey` => `RelayWSSigningKey` (pk of EOA whitelisted by the relay)
Header `X-api-header` => `X-Auth-Message` (json of signature of current UTC timestamp --relay will authenticate connection as long as it is +- 5mins and a valid signature-- and  coinbase address)

[Branch](https://github.com/flashbots/mev-geth-demo/tree/v0.2-ws-eth-keys) of updated e2e demo.