### PR TITLE
Added keystore support for ws auth

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -153,6 +153,8 @@ var (
 		utils.MinerNotifyFullFlag,
 		utils.RelayWSURL,
 		utils.RelayWSSigningKey,
+		utils.RelayWSSigningKeystoreDir,
+		utils.RelayWSKeystorePW,
 		configFileFlag,
 	}
 

--- a/node/config.go
+++ b/node/config.go
@@ -168,6 +168,10 @@ type Config struct {
 	RelayWSURL string
 	// RelayWSSigningKey is the ethereum private key of a whitelisted eoa, required to authenticate with the relay ws server
 	RelayWSSigningKey string
+	// RelayWSSigningKeystoreDir allows WS authentication signing via keystore files
+	RelayWSSigningKeystoreDir string
+	// RelayWSKeystorePW is the password of the WS auth keystore
+	RelayWSKeystorePW string
 
 	// WSExposeAll exposes all API modules via the WebSocket RPC interface rather
 	// than just the public ones.


### PR DESCRIPTION
New flags: 

`--relayWSSigningKeystoreDir ` // directory of keystore file
`--relayWSKeystorePW` // password of keystore file

Defaults to keystore file if both the above flags and `--relayWSSigningkey` are provided 

[Demo branch](https://github.com/flashbots/mev-geth-demo/tree/v0.2-ws-eth-keys)