### PR TITLE
flashbots: fix bug in double counting gas for profit switcher

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1196,7 +1196,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		if w.commitBundle(bundleTxs, w.coinbase, interrupt) {
 			return
 		}
-		w.current.profit.Add(w.current.profit, bundle.totalEth)
+		w.current.profit.Add(w.current.profit, bundle.ethSentToCoinbase)
 	}
 	if len(localTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, localTxs, header.BaseFee)


### PR DESCRIPTION
Only add in the eth sent to coinbase, since the gas fees are counted
already in commitTransaction