### PR TITLE
feat(ethash): flashbots_getWork RPC with profit

### DIFF
--- a/cmd/evm/internal/t8ntool/block.go
+++ b/cmd/evm/internal/t8ntool/block.go
@@ -188,7 +188,7 @@ func (i *bbInput) sealEthash(block *types.Block) (*types.Block, error) {
 	// If the testmode is used, the sealer will return quickly, and complain
 	// "Sealing result is not read by miner" if it cannot write the result.
 	results := make(chan *types.Block, 1)
-	if err := engine.Seal(nil, block, results, nil); err != nil {
+	if err := engine.Seal(nil, block, nil, results, nil); err != nil {
 		panic(fmt.Sprintf("failed to seal block: %v", err))
 	}
 	found := <-results

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -590,7 +590,7 @@ func (c *Clique) Authorize(signer common.Address, signFn SignerFn) {
 
 // Seal implements consensus.Engine, attempting to create a sealed block using
 // the local signing credentials.
-func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, profit *big.Int, results chan<- *types.Block, stop <-chan struct{}) error {
 	header := block.Header()
 
 	// Sealing the genesis block is not supported

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -102,7 +102,7 @@ type Engine interface {
 	//
 	// Note, the method returns immediately and will send the result async. More
 	// than one result may also be returned depending on the consensus algorithm.
-	Seal(chain ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error
+	Seal(chain ChainHeaderReader, block *types.Block, profit *big.Int, results chan<- *types.Block, stop <-chan struct{}) error
 
 	// SealHash returns the hash of a block prior to it being sealed.
 	SealHash(header *types.Header) common.Hash

--- a/consensus/ethash/api.go
+++ b/consensus/ethash/api.go
@@ -44,7 +44,7 @@ func (api *API) GetWork() ([4]string, error) {
 	}
 
 	var (
-		workCh = make(chan [4]string, 1)
+		workCh = make(chan [5]string, 1)
 		errc   = make(chan error, 1)
 	)
 	select {
@@ -53,7 +53,10 @@ func (api *API) GetWork() ([4]string, error) {
 		return [4]string{}, errEthashStopped
 	}
 	select {
-	case work := <-workCh:
+	case fullWork := <-workCh:
+		var work [4]string
+		copy(work[:], fullWork[:4])
+
 		return work, nil
 	case err := <-errc:
 		return [4]string{}, err

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -683,6 +683,12 @@ func (ethash *Ethash) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 			Service:   &API{ethash},
 			Public:    true,
 		},
+		{
+			Namespace: "flashbots",
+			Version:   "1.0",
+			Service:   &FlashbotsAPI{ethash},
+			Public:    true,
+		},
 	}
 }
 

--- a/consensus/ethash/ethash_test.go
+++ b/consensus/ethash/ethash_test.go
@@ -38,7 +38,7 @@ func TestTestMode(t *testing.T) {
 	defer ethash.Close()
 
 	results := make(chan *types.Block)
-	err := ethash.Seal(nil, types.NewBlockWithHeader(header), results, nil)
+	err := ethash.Seal(nil, types.NewBlockWithHeader(header), nil, results, nil)
 	if err != nil {
 		t.Fatalf("failed to seal block: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestRemoteSealer(t *testing.T) {
 
 	// Push new work.
 	results := make(chan *types.Block)
-	ethash.Seal(nil, block, results, nil)
+	ethash.Seal(nil, block, nil, results, nil)
 
 	var (
 		work [4]string
@@ -128,7 +128,7 @@ func TestRemoteSealer(t *testing.T) {
 	header = &types.Header{Number: big.NewInt(1), Difficulty: big.NewInt(1000)}
 	block = types.NewBlockWithHeader(header)
 	sealhash = ethash.SealHash(header)
-	ethash.Seal(nil, block, results, nil)
+	ethash.Seal(nil, block, nil, results, nil)
 
 	if work, err = api.GetWork(); err != nil || work[0] != sealhash.Hex() {
 		t.Error("expect to return the latest pushed work")

--- a/consensus/ethash/flashbots_api.go
+++ b/consensus/ethash/flashbots_api.go
@@ -1,0 +1,38 @@
+package ethash
+
+import "errors"
+
+// FlashbotsAPI exposes Flashbots related methods for the RPC interface.
+type FlashbotsAPI struct {
+	ethash *Ethash
+}
+
+// GetWork returns a work package for external miner.
+//
+// The work package consists of 5 strings:
+//   result[0] - 32 bytes hex encoded current block header pow-hash
+//   result[1] - 32 bytes hex encoded seed hash used for DAG
+//   result[2] - 32 bytes hex encoded boundary condition ("target"), 2^256/difficulty
+//   result[3] - hex encoded block number
+//   result[4] - hex encoded profit generated from this block
+func (api *FlashbotsAPI) GetWork() ([5]string, error) {
+	if api.ethash.remote == nil {
+		return [5]string{}, errors.New("not supported")
+	}
+
+	var (
+		workCh = make(chan [5]string, 1)
+		errc   = make(chan error, 1)
+	)
+	select {
+	case api.ethash.remote.fetchWorkCh <- &sealWork{errc: errc, res: workCh}:
+	case <-api.ethash.remote.exitCh:
+		return [5]string{}, errEthashStopped
+	}
+	select {
+	case work := <-workCh:
+		return work, nil
+	case err := <-errc:
+		return [5]string{}, err
+	}
+}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -641,7 +641,7 @@ func (w *worker) taskLoop() {
 			w.pendingTasks[sealHash] = task
 			w.pendingMu.Unlock()
 
-			if err := w.engine.Seal(w.chain, task.block, w.resultCh, stopCh); err != nil {
+			if err := w.engine.Seal(w.chain, task.block, task.profit, w.resultCh, stopCh); err != nil {
 				log.Warn("Block sealing failed", "err", err)
 				w.pendingMu.Lock()
 				delete(w.pendingTasks, sealHash)


### PR DESCRIPTION
https://github.com/flashbots/mev-geth/issues/103

Adds new RPC method `flashbots_getWork` which adds a new block reward including MEV to `eth_getWork` RPC result.

Block reward matches the profit number used in the mining worker
https://github.com/flashbots/mev-geth/blob/516e2c3982109dd4176f3eae71015dd385f65ea2/miner/worker.go#L105

---

Not sure how I can test it, but running on Sepolia with (`mainnet` in the log is a bug, see https://github.com/ethereum/go-ethereum/pull/24147)
```console
➜  mev-geth git:(feat/flashbots-get-work) ./build/bin/geth --sepolia --mine
INFO [12-22|09:45:39.458] Starting Geth on Ethereum mainnet... 
```

successfully returns both `eth_getWork` and `flashbots_getWork` RPCs
```console
> web3.currentProvider.send({method: 'eth_getWork'})
{
  id: 0,
  jsonrpc: "2.0",
  result: ["0x61459bbdf3c56b8e7d281fca4210e440daf95526e59f7068ec61681980ac9da2", "0x9b2baad7528ecec612c5751a6bd525905892d7892e155c3b05e61363154a940b", "0x0000000a9f8ed07e7747b5db09228583fe0410d0c823bd414157935370bbe9fe", "0x50357"]
}
> web3.currentProvider.send({method: 'flashbots_getWork'})
{
  id: 0,
  jsonrpc: "2.0",
  result: ["0x61459bbdf3c56b8e7d281fca4210e440daf95526e59f7068ec61681980ac9da2", "0x9b2baad7528ecec612c5751a6bd525905892d7892e155c3b05e61363154a940b", "0x0000000a9f8ed07e7747b5db09228583fe0410d0c823bd414157935370bbe9fe", "0x50357", "0x0"]
}
```

Guess I could try syncing Ropsten and trying to mine it watching for `profit` value in `flashbots_getWork` response.