### PR TITLE
Set floor gas price to next bundle's mevGasPrice

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1264,7 +1264,6 @@ func (w *worker) fillTransactions(interrupt *int32, env *environment) bool {
 			log.Error("Failed to fetch pending transactions", "err", err)
 			return true
 		}
-		w.eth.TxPool().GasPrice()
 
 		bundleTxs, bundle, numBundles, err := w.generateFlashbotsBundle(env, bundles, pending)
 		if err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1502,7 +1502,7 @@ func (w *worker) mergeBundles(env *environment, bundles []simulatedBundle, pendi
 		if i == len(bundles)-1 {
 			// the floor gas price is 99/100 what was simulated at the top of the block
 			// TODO: It would be more profitable to set floorGasPrice = min(gas price of txs in pendingTxs)
-			//   if gasusedby(pendingTxs) + simmedTxs.totalGasUsed > gas limit
+			//   if gasusedby(pendingTxs) + simmed.totalGasUsed > gas limit
 			floorGasPrice = new(big.Int).Mul(bundle.mevGasPrice, big.NewInt(99))
 			floorGasPrice = floorGasPrice.Div(floorGasPrice, big.NewInt(100))
 		} else {


### PR DESCRIPTION
For all but the lowest priced bundle, set the `floorGasPrice` variable in `worker.mergeBundles` to the `mevGasPrice` of the next highest scored bundle. 

This change should increase (or not affect) the bundle revenues for a given block. 